### PR TITLE
Make KeyValueFetcher generic on the key/value type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_cache:
 matrix:
   include:
   - env: PROJECT="lib"
-  - env: PROJECT="examples"
 script:
 - cd "${PROJECT}"
 - sbt +test

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -3,7 +3,7 @@ import NativePackagerHelper._
 
 name := "QueryExampleProject-root"
 
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.1.1"
 
 scalaVersion := Versions.scalaVersion
 
@@ -17,6 +17,7 @@ lazy val dslRun = (project in file("./example-dsl"))
   .settings (
     fork in run := true,
     mainClass in Compile := Some("com.lightbend.kafka.scala.iq.example.WeblogProcessing"),
+    scalacOptions := Seq("-Xexperimental", "-unchecked", "-deprecation", "-Ywarn-unused-import"),
     javaOptions in run ++= Seq(
       "-Dconfig.file=" + (resourceDirectory in Compile).value / "application-dsl.conf",
       "-Dlogback.configurationFile=" + (resourceDirectory in Compile).value / "logback-dsl.xml",
@@ -59,6 +60,7 @@ lazy val procRun = (project in file("./example-proc"))
   .settings (
     fork in run := true,
     mainClass in Compile := Some("com.lightbend.kafka.scala.iq.example.WeblogDriver"),
+    scalacOptions := Seq("-Xexperimental", "-unchecked", "-deprecation", "-Ywarn-unused-import"),
     javaOptions in run ++= Seq(
       "-Dconfig.file=" + (resourceDirectory in Compile).value / "application-proc.conf",
       "-Dlogback.configurationFile=" + (resourceDirectory in Compile).value / "logback-proc.xml",

--- a/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/config/KStreamConfig.scala
+++ b/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/config/KStreamConfig.scala
@@ -5,7 +5,6 @@
 package com.lightbend.kafka.scala.iq.example
 package config
 
-import cats._
 import cats.data._
 import cats.instances.all._
 

--- a/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/http/SummaryInfoFetcher.scala
+++ b/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/http/SummaryInfoFetcher.scala
@@ -8,7 +8,7 @@ package http
 import com.lightbend.kafka.scala.iq.http.KeyValueFetcher
 import scala.concurrent.Future
 
-class SummaryInfoFetcher(kvf: KeyValueFetcher) {
+class SummaryInfoFetcher(kvf: KeyValueFetcher[String, Long]) {
   def fetchAccessCountSummary(hostKey: String): Future[Long] =
     kvf.fetch(hostKey, WeblogProcessing.ACCESS_COUNT_PER_HOST_STORE, "/weblog/access/" + hostKey)
 

--- a/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/http/WeblogDSLHttpService.scala
+++ b/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/http/WeblogDSLHttpService.scala
@@ -15,7 +15,7 @@ import io.circe.syntax._
 import org.apache.kafka.streams.state.HostInfo
 
 import scala.concurrent.ExecutionContext
-import com.lightbend.kafka.scala.iq.http.{ InteractiveQueryHttpService, KeyValueFetcher }
+import com.lightbend.kafka.scala.iq.http.InteractiveQueryHttpService
 
 
 class WeblogDSLHttpService(

--- a/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/serializers/SpecificAvroDeserializerWithSchemaRegistry.scala
+++ b/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/serializers/SpecificAvroDeserializerWithSchemaRegistry.scala
@@ -8,7 +8,6 @@ package serializers
 import org.apache.kafka.common.serialization.Deserializer
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.HashMap
 
 import java.util.{ Map => JMap }
 

--- a/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/serializers/SpecificAvroSerdeWithSchemaRegistry.scala
+++ b/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/serializers/SpecificAvroSerdeWithSchemaRegistry.scala
@@ -7,7 +7,6 @@ package serializers
 
 import org.apache.kafka.common.serialization.{ Deserializer, Serde, Serdes, Serializer }
 
-import java.util.Collections
 import java.util.Map
 
 class SpecificAvroSerdeWithSchemaRegistry[T <: org.apache.avro.specific.SpecificRecord] extends Serde[T] {

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/WeblogDriver.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/WeblogDriver.scala
@@ -5,19 +5,15 @@
 package com.lightbend.kafka.scala.iq.example
 
 import java.util.Properties
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.Executors
 
-import scala.collection.JavaConverters._
-import scala.util.{ Success, Failure }
 import scala.concurrent.ExecutionContext
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 
 import org.apache.kafka.streams.Topology
-import org.apache.kafka.streams.processor.StateStoreSupplier
-import org.apache.kafka.streams.state.{ Stores, HostInfo }
+import org.apache.kafka.streams.state.HostInfo
 import org.apache.kafka.streams.{ StreamsConfig, KafkaStreams }
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/config/KStreamConfig.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/config/KStreamConfig.scala
@@ -5,7 +5,6 @@
 package com.lightbend.kafka.scala.iq.example
 package config
 
-import cats._
 import cats.data._
 import cats.instances.all._
 

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/http/BFValueFetcher.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/http/BFValueFetcher.scala
@@ -5,12 +5,10 @@
 package com.lightbend.kafka.scala.iq.example
 package http
 
-import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
 
 import org.apache.kafka.streams.{ KafkaStreams }
 import org.apache.kafka.streams.state.HostInfo
-import org.apache.kafka.common.serialization.StringSerializer
 
 import scala.concurrent.{ Future, ExecutionContext}
 import scala.util.{ Success, Failure }

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/http/WeblogProcHttpService.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/http/WeblogProcHttpService.scala
@@ -9,7 +9,6 @@ import akka.actor.ActorSystem
 
 import akka.stream.ActorMaterializer
 
-import io.circe.generic.auto._
 import io.circe.syntax._
 
 import org.apache.kafka.streams.state.HostInfo

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/BFStore.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/BFStore.scala
@@ -9,7 +9,6 @@ import com.twitter.algebird.{BloomFilterMonoid, BF, Hash128, Approximate}
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.processor.{ProcessorContext, StateStore}
 import org.apache.kafka.streams.state.StateSerdes
-import org.apache.kafka.streams.processor.internals.{ProcessorStateManager, RecordCollector}
 
 /**
  * Bloom Filter as a StateStore. The only query it supports is membership.

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/BFStoreChangeLogger.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/BFStoreChangeLogger.scala
@@ -6,7 +6,7 @@ package com.lightbend.kafka.scala.iq.example
 package processor
 
 import org.apache.kafka.streams.processor.ProcessorContext
-import org.apache.kafka.streams.processor.internals.{ProcessorStateManager, RecordCollector, ProcessorContextImpl}
+import org.apache.kafka.streams.processor.internals.{ProcessorStateManager, RecordCollector}
 import org.apache.kafka.streams.state.StateSerdes
 
 class BFStoreChangeLogger[K, V](val storeName: String,

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/BFStoreType.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/BFStoreType.scala
@@ -9,7 +9,7 @@ import org.apache.kafka.streams.state.QueryableStoreType
 import org.apache.kafka.streams.processor.StateStore
 import org.apache.kafka.streams.state.internals.StateStoreProvider
 
-import com.twitter.algebird.{ Hash128, ApproximateBoolean }
+import com.twitter.algebird.Hash128
 
 import scala.collection.JavaConverters._
 

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/WeblogProcessor.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/processor/WeblogProcessor.scala
@@ -7,7 +7,7 @@ package processor
 
 import scala.util.{ Success, Failure }
 import org.apache.kafka.streams.processor.{ AbstractProcessor, ProcessorContext, PunctuationType, Punctuator }
-import models.{ LogParseUtil, LogRecord }
+import models.LogParseUtil
 import com.typesafe.scalalogging.LazyLogging
 
 class WeblogProcessor extends AbstractProcessor[String, String] with LazyLogging {

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/services/LocalStateStoreQuery.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/services/LocalStateStoreQuery.scala
@@ -7,11 +7,10 @@ package services
 
 import org.apache.kafka.streams.KafkaStreams
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{Future, ExecutionContext}
 import akka.actor.ActorSystem
 
-import processor.{ BFStore, ReadableBFStore, BFStoreType }
+import processor.BFStoreType
 import com.twitter.algebird.Hash128
 
 import com.lightbend.kafka.scala.iq.services.LocalStateStoreQuery

--- a/examples/project/Versions.scala
+++ b/examples/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
-  val ksVersion = "0.1.0"
-  val kqVersion = "0.1.0"
+  val ksVersion = "0.1.1"
+  val kqVersion = "0.1.1"
   val scala2_12Version = "2.12.4"
   val scala2_11Version = "2.11.11"
   val scalaVersion = scala2_12Version
@@ -8,11 +8,11 @@ object Versions {
   val algebirdVersion = "0.13.0"
   val chillVersion = "0.9.2"
   val bijectionVersion = "0.9.5"
-  val alpakkaFileVersion = "0.10"
-  val reactiveKafkaVersion = "0.17"
+  val alpakkaFileVersion = "0.16"
+  val reactiveKafkaVersion = "0.18"
   val confluentPlatformVersion = "3.3.0"
   val akkaVersion = "2.5.3"
-  val akkaHttpVersion = "10.0.10"
+  val akkaHttpVersion = "10.0.11"
   val akkaHttpCirceVersion = "1.17.0"
   val circeVersion = "0.8.0"
   val scalaLoggingVersion = "3.5.0"

--- a/lib/build.sbt
+++ b/lib/build.sbt
@@ -10,7 +10,7 @@ scalaVersion := Versions.scalaVersion
 
 crossScalaVersions := Versions.crossScalaVersions
 
-scalacOptions := Seq("-Xexperimental", "-unchecked", "-deprecation")
+scalacOptions := Seq("-Xexperimental", "-unchecked", "-deprecation", "-Ywarn-unused-import")
 
 parallelExecution in Test := false
 

--- a/lib/build.sbt
+++ b/lib/build.sbt
@@ -4,7 +4,7 @@ name := "kafka-streams-query"
 
 organization := "com.lightbend"
 
-version := "0.2.0-SNAPSHOT"
+version := "0.1.1"
 
 scalaVersion := Versions.scalaVersion
 

--- a/lib/project/Versions.scala
+++ b/lib/project/Versions.scala
@@ -11,7 +11,7 @@ object Versions {
   val crossScalaVersions = Seq(scalaVersion, "2.11.11")
   val circeVersion = "0.8.0"
   val akkaVersion = "2.5.3"
-  val akkaHttpVersion = "10.0.10"
+  val akkaHttpVersion = "10.0.11"
   val akkaHttpCirceVersion = "1.17.0"
   val bijectionVersion = "0.9.5"
 }

--- a/lib/src/main/scala/com/lightbend/kafka/scala/iq/http/HttpRequester.scala
+++ b/lib/src/main/scala/com/lightbend/kafka/scala/iq/http/HttpRequester.scala
@@ -7,13 +7,11 @@ package http
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.client.RequestBuilding
 
 import akka.http.scaladsl.model.{ HttpResponse, HttpRequest, ResponseEntity }
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 
-import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.ActorMaterializer
 
 import scala.concurrent.{ Future, ExecutionContext}

--- a/lib/src/main/scala/com/lightbend/kafka/scala/iq/http/InteractiveQueryHttpService.scala
+++ b/lib/src/main/scala/com/lightbend/kafka/scala/iq/http/InteractiveQueryHttpService.scala
@@ -8,24 +8,20 @@ package http
 import akka.actor.ActorSystem
 
 import akka.http.scaladsl.server.Directives
-import Directives._
 import akka.http.scaladsl.Http
 
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.server.{ ExceptionHandler, Route }
+import akka.http.scaladsl.server.ExceptionHandler
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 
-import io.circe.generic.auto._
-import io.circe.syntax._
-
 import org.apache.kafka.streams.state.HostInfo
 
 import scala.concurrent.{ Future, ExecutionContext}
-import scala.util.{ Try, Success, Failure }
+import scala.util.{ Success, Failure }
 
 import com.typesafe.scalalogging.LazyLogging
 

--- a/lib/src/main/scala/com/lightbend/kafka/scala/iq/http/KeyValueFetcher.scala
+++ b/lib/src/main/scala/com/lightbend/kafka/scala/iq/http/KeyValueFetcher.scala
@@ -5,12 +5,11 @@
 package com.lightbend.kafka.scala.iq
 package http
 
-import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
 
 import org.apache.kafka.streams.{ KafkaStreams }
 import org.apache.kafka.streams.state.HostInfo
-import org.apache.kafka.common.serialization.StringSerializer
+import org.apache.kafka.common.serialization.Serializer
 
 import scala.concurrent.{ Future, ExecutionContext}
 import scala.util.{ Success, Failure }
@@ -18,7 +17,10 @@ import scala.util.{ Success, Failure }
 import com.typesafe.scalalogging.LazyLogging
 import services.{ MetadataService, HostStoreInfo, LocalStateStoreQuery }
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import akka.http.scaladsl.model.ResponseEntity
+import akka.http.scaladsl.unmarshalling.Unmarshaller
 import serializers.Serializers
+import io.circe.Decoder
 
 /**
  * Abstraction for fetching information from a key/value state store based on the
@@ -30,24 +32,27 @@ import serializers.Serializers
  * then fetches the store information from the MetadataService and then requeries that store
  * to get the information.
  */ 
-class KeyValueFetcher(
+class KeyValueFetcher[K, V: Decoder](
   metadataService: MetadataService, 
-  localStateStoreQuery: LocalStateStoreQuery[String, Long],
+  localStateStoreQuery: LocalStateStoreQuery[K, V],
   httpRequester: HttpRequester, 
   streams: KafkaStreams, 
   executionContext: ExecutionContext, 
-  hostInfo: HostInfo)(implicit actorSystem: ActorSystem) extends LazyLogging with FailFastCirceSupport with Serializers {
+  hostInfo: HostInfo)(implicit actorSystem: ActorSystem, keySerializer: Serializer[K], u: Unmarshaller[ResponseEntity, V])
+
+  extends LazyLogging 
+  with FailFastCirceSupport with Serializers {
 
   private implicit val ec: ExecutionContext = executionContext
 
-  def fetch(key: String, store: String, path: String): Future[Long] = { 
+  def fetch(key: K, store: String, path: String): Future[V] = { 
 
-    metadataService.streamsMetadataForStoreAndKey(store, key, stringSerializer) match {
+    metadataService.streamsMetadataForStoreAndKey(store, key, keySerializer) match {
       case Success(host) => {
         // key is on another instance. call the other instance to fetch the data.
         if (!thisHost(host)) {
           logger.warn(s"Key $key is on another instance not on $host - requerying ..")
-          httpRequester.queryFromHost[Long](host, path)
+          httpRequester.queryFromHost[V](host, path)
         } else {
           // key is on this instance
           localStateStoreQuery.queryStateStore(streams, store, key)
@@ -57,15 +62,15 @@ class KeyValueFetcher(
     }
   }
 
-  def fetchWindowed(key: String, store: String, path: String, 
-    fromTime: Long, toTime: Long): Future[List[(Long, Long)]] = 
+  def fetchWindowed(key: K, store: String, path: String, 
+    fromTime: Long, toTime: Long): Future[List[(Long, V)]] = 
 
-    metadataService.streamsMetadataForStoreAndKey(store, key, stringSerializer) match {
+    metadataService.streamsMetadataForStoreAndKey(store, key, keySerializer) match {
       case Success(host) => {
         // key is on another instance. call the other instance to fetch the data.
         if (!thisHost(host)) {
           logger.warn(s"Key $key is on another instance not on $host - requerying ..")
-          httpRequester.queryFromHost[List[(Long, Long)]](host, path)
+          httpRequester.queryFromHost[List[(Long, V)]](host, path)
         } else {
           // key is on this instance
           localStateStoreQuery.queryWindowedStateStore(streams, store, key, fromTime, toTime)

--- a/lib/src/main/scala/com/lightbend/kafka/scala/iq/serializers/ModelSerializer.scala
+++ b/lib/src/main/scala/com/lightbend/kafka/scala/iq/serializers/ModelSerializer.scala
@@ -7,7 +7,7 @@ package serializers
 
 import java.util.Map
 
-import io.circe._, io.circe.generic.auto._, io.circe.parser._, io.circe.syntax._
+import io.circe._, io.circe.parser._, io.circe.syntax._
 
 
 class ModelSerializer[T : Encoder : Decoder] extends SerDeserializer[T] {

--- a/lib/src/main/scala/com/lightbend/kafka/scala/iq/services/LocalStateStoreQuery.scala
+++ b/lib/src/main/scala/com/lightbend/kafka/scala/iq/services/LocalStateStoreQuery.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import com.typesafe.scalalogging.LazyLogging
-import akka.actor.{ActorSystem, Scheduler}
+import akka.actor.ActorSystem
 
 /**
  * Abstraction that supports query from a local state store. The query supports retry semantics if 


### PR DESCRIPTION
This PR does the following:

1. Makes `KeyValueFetcher` generic (Fixes https://github.com/lightbend/kafka-streams-query/issues/8)
2. Changes the examples to handle impacts from 1.
3. Cleanup of unused imports