### PR TITLE
[DO NOT MERGE] example-dsl now uses implicit serde from kafka-streams-scala

### DIFF
--- a/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/serializers/AppSerializers.scala
+++ b/examples/example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/serializers/AppSerializers.scala
@@ -6,7 +6,7 @@ package com.lightbend.kafka.scala.iq.example
 package serializers
 
 import models.LogRecord
-import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.common.serialization.{ Serdes, Serializer, Deserializer, Serde }
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
 import com.lightbend.kafka.scala.iq.serializers._
 
@@ -14,14 +14,19 @@ trait AppSerializers extends Serializers {
   final val ts = new Tuple2Serializer[String, String]()
   final val ms = new ModelSerializer[LogRecord]()
   final val logRecordSerde = Serdes.serdeFrom(ms, ms)
-  final val tuple2StringSerde = Serdes.serdeFrom(ts, ts)
+
+  implicit val baSerde = byteArraySerde
+  implicit val tuple2StringSerde = Serdes.serdeFrom(ts, ts)
+  implicit val wss = windowedStringSerde
+  implicit val ss = stringSerde
+  implicit val ls = longSerde
 
   /**
    * The Serde instance varies depending on whether we are using Schema Registry. If we are using
    * schema registry, we use the serde provided by Confluent, else we use Avro serialization backed by
    * Twitter's bijection library
    */ 
-  def logRecordAvroSerde(maybeSchemaRegistryUrl: Option[String]) = maybeSchemaRegistryUrl.map { url =>
+  def logRecordAvroSerde(maybeSchemaRegistryUrl: Option[String]): Serde[LogRecordAvro] = maybeSchemaRegistryUrl.map { url =>
     val serde = new SpecificAvroSerdeWithSchemaRegistry[LogRecordAvro]()
     serde.configure(
         java.util.Collections.singletonMap(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, url),
@@ -30,4 +35,13 @@ trait AppSerializers extends Serializers {
   }.getOrElse {
     new SpecificAvroSerde[LogRecordAvro](LogRecordAvro.SCHEMA$)
   }
+}
+
+class LogRecordSerde extends Serde[LogRecord] {
+  private val lrSer = new ModelSerializer[LogRecord]
+
+  override def serializer(): Serializer[LogRecord] = lrSer
+  override def deserializer(): Deserializer[LogRecord] = lrSer
+  override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = lrSer.configure(configs, isKey)
+  override def close(): Unit = lrSer.close
 }

--- a/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/WeblogDriver.scala
+++ b/examples/example-proc/src/main/scala/com/lightbend/kafka/scala/iq/example/WeblogDriver.scala
@@ -104,7 +104,7 @@ object WeblogDriver extends WeblogWorkflow {
 
     val topology: Topology = new Topology()
     topology.addSource("Source", config.fromTopic)
-            .addProcessor("Process", WeblogProcessorSupplier, "Source")
+            .addProcessor("Process", () => new WeblogProcessor, "Source")
             .addStateStore(
               new BFStoreBuilder[String](new BFStoreSupplier[String](LOG_COUNT_STATE_STORE, stringSerde, true, changelogConfig)), 
               "Process"
@@ -112,9 +112,4 @@ object WeblogDriver extends WeblogWorkflow {
 
     new KafkaStreams(topology, streamingConfig)
   }
-}
-
-import org.apache.kafka.streams.processor.ProcessorSupplier
-object WeblogProcessorSupplier extends ProcessorSupplier[String, String] {
-  override def get(): WeblogProcessor = new WeblogProcessor()
 }

--- a/examples/project/Versions.scala
+++ b/examples/project/Versions.scala
@@ -1,5 +1,5 @@
 object Versions {
-  val ksVersion = "0.1.2"
+  val ksVersion = "0.1.3"
   val kqVersion = "0.1.1"
   val scala2_12Version = "2.12.4"
   val scala2_11Version = "2.11.11"


### PR DESCRIPTION
This PR is a demonstration of using implicit serde from `kafka-streams-scala`. `example-dsl` now uses implicit serde.